### PR TITLE
Add operation generator with optional namespace and test generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/tmp/
 /tmp/
 
 # rspec failure tracking

--- a/lib/generators/rails_cosmos/operation_generator.rb
+++ b/lib/generators/rails_cosmos/operation_generator.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails/generators/named_base"
+
+module RailsCosmos
+  module Generators
+    # This generator creates a new operation class within the `app/operations` directory.
+    # Optionally, you can specify a namespace, and it will create a subdirectory based on that namespace.
+    #
+    # Example usage:
+    #
+    #   rails generate operation NAME NAMESPACE
+    #
+    # If a namespace is provided, the generated operation will be placed inside a folder corresponding to
+    # the namespace within `app/operations`. If no namespace is provided, the operation will be created
+    # directly within the `app/operations` directory.
+    #
+    # This generator also creates a test file for the operation. If RSpec is detected, the test will be
+    # placed under `spec/operations`, and if MiniTest is detected, it will be placed under `test/operations`.
+    # If neither test framework is detected, the test generation will be skipped with a warning.
+    #
+    # Arguments:
+    #   NAME        - The name of the operation (required).
+    #   NAMESPACE   - The namespace for the operation (optional).
+    #
+    # Example:
+    #
+    #   rails generate rails_cosmos:operation create_user admin
+    #
+    # This will generate:
+    #
+    #   app/operations/admin/create_user.rb
+    #   spec/operations/admin/create_user_spec.rb (if RSpec is used)
+    #   or
+    #   test/operations/admin/create_user_test.rb (if MiniTest is used)
+    #
+    class OperationGenerator < Rails::Generators::NamedBase
+      source_root File.expand_path("../templates", __dir__)
+
+      argument :namespace, type: :string, optional: true, desc: "Optional namespace for the operation"
+
+      def create_operation_file
+        operation_directory = operation_directory_path
+        operation_file = "#{operation_directory}/#{file_name}.rb"
+
+        empty_directory operation_directory
+        template "operation_template.rb.tt", operation_file
+      end
+
+      def create_test_file
+        if rspec_installed?
+          create_rspec_test_file
+        elsif minitest_installed?
+          create_minitest_test_file
+        else
+          say_status("warning", "No supported test framework found. Skipping test file generation.", :yellow)
+        end
+      end
+
+      private
+
+      def file_name
+        name.underscore
+      end
+
+      def operation_directory_path
+        namespace ? File.join("app/operations", namespace.underscore) : "app/operations"
+      end
+
+      def test_directory_path
+        if namespace
+          namespace_dir = namespace.underscore
+          rspec_installed? ? File.join("spec/operations", namespace_dir) : File.join("test/operations", namespace_dir)
+        else
+          rspec_installed? ? "spec/operations" : "test/operations"
+        end
+      end
+
+      def rspec_installed?
+        File.exist?(File.join(destination_root, "spec/spec_helper.rb"))
+      end
+
+      def minitest_installed?
+        File.exist?(File.join(destination_root, "test/test_helper.rb"))
+      end
+
+      def create_rspec_test_file
+        empty_directory test_directory_path
+        template "rspec_operation_test.rb.tt", File.join(test_directory_path, "#{file_name}_spec.rb")
+      end
+
+      def create_minitest_test_file
+        empty_directory test_directory_path
+        template "minitest_operation_test.rb.tt", File.join(test_directory_path, "#{file_name}_test.rb")
+      end
+    end
+  end
+end

--- a/lib/generators/templates/minitest_operation_test.rb.tt
+++ b/lib/generators/templates/minitest_operation_test.rb.tt
@@ -1,0 +1,14 @@
+require "test_helper"
+
+<% if namespace -%>
+class <%= namespace.camelcase %>::<%= file_name.camelcase %>Test < ActiveSupport::TestCase
+  test "executes call successfully" do
+    result = <%= namespace.camelcase %>::<%= file_name.camelcase %>.call
+<% else -%>
+class <%= file_name.camelcase %>Test < ActiveSupport::TestCase
+  test "executes call successfully" do
+    result = <%= file_name.camelcase %>.call
+<% end -%>
+    assert result.first
+  end
+end

--- a/lib/generators/templates/operation_template.rb.tt
+++ b/lib/generators/templates/operation_template.rb.tt
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+<% if namespace -%>
+module <%= namespace.camelcase %>
+  class <%= file_name.camelcase %> < ApplicationOperation
+    def initialize(log_uuid: nil)
+      super(log_uuid:)
+    end
+
+    def call
+      # Add your business logic here, if necessary
+      # adding additional methods, we encourage the
+      # use of private functions below
+
+      success(self)
+    end
+  end
+end
+<% else -%>
+class <%= file_name.camelcase %> < ApplicationOperation
+  def initialize(log_uuid: nil)
+    super(log_uuid:)
+  end
+
+  def call
+    # Add your business logic here, if necessary
+    # adding additional methods, we encourage the
+    # use of private functions below
+
+    success(self)
+  end
+end
+<% end -%>

--- a/lib/generators/templates/rspec_operation_test.rb.tt
+++ b/lib/generators/templates/rspec_operation_test.rb.tt
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+<% if namespace -%>
+RSpec.describe <%= namespace.camelcase %>::<%= file_name.camelcase %>, type: :operation do
+<% else -%>
+RSpec.describe <%= file_name.camelcase %>, type: :operation do
+<% end -%>
+  it "executes call successfully" do
+    result = described_class.call
+    expect(result.first).to be_truthy
+  end
+end

--- a/lib/rails_cosmos.rb
+++ b/lib/rails_cosmos.rb
@@ -2,6 +2,7 @@
 
 require_relative "rails_cosmos/version"
 require_relative "generators/rails_cosmos/install_generator"
+require_relative "generators/rails_cosmos/operation_generator"
 
 module RailsCosmos
   class Error < StandardError; end

--- a/spec/install_generator_spec.rb
+++ b/spec/install_generator_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe RailsCosmos::Generators::InstallGenerator, type: :generator do
   end
 
   it "creates the operation directory and file" do
-    expect(1).to eq 1
     expect(File).to exist("#{destination_root}/app/operations/application_operation.rb")
   end
 end

--- a/spec/operation_generator_spec.rb
+++ b/spec/operation_generator_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require "generator_spec"
+require "generators/rails_cosmos/install_generator"
+
+RSpec.describe RailsCosmos::Generators::OperationGenerator, type: :generator do
+  destination File.expand_path("tmp/generators", __dir__)
+
+  before do
+    prepare_destination
+  end
+
+  describe "without a namespace" do
+    it "creates an operation file in the app/operations directory" do
+      run_generator %w[CreateUser]
+
+      assert_file "app/operations/create_user.rb", /class CreateUser < ApplicationOperation/
+    end
+
+    it "creates an RSpec test file if RSpec is detected" do
+      allow(File).to receive(:exist?).with(anything).and_call_original
+      allow(File).to receive(:exist?).with(File.join(destination_root, "spec/spec_helper.rb")).and_return(true)
+
+      run_generator %w[CreateUser]
+
+      assert_file "spec/operations/create_user_spec.rb", /RSpec.describe CreateUser, type: :operation do/
+    end
+
+    it "skips test file creation if no test framework is detected" do
+      allow(File).to receive(:exist?).with(anything).and_call_original
+      allow(File).to receive(:exist?).with(File.join(destination_root, "spec/spec_helper.rb")).and_return(false)
+      allow(File).to receive(:exist?).with(File.join(destination_root, "test/test_helper.rb")).and_return(false)
+
+      run_generator %w[CreateUser]
+
+      expect(destination_root).not_to have_structure {
+        directory "spec/operations" do
+          file "create_user_spec.rb"
+        end
+        directory "test/operations" do
+          file "create_user_test.rb"
+        end
+      }
+    end
+  end
+
+  describe "with a namespace" do
+    it "creates an operation file in the appropriate namespace directory" do
+      run_generator %w[CreateUser Admin]
+
+      assert_file "app/operations/admin/create_user.rb", /module Admin\r\n  class CreateUser < ApplicationOperation/
+    end
+
+    it "creates an RSpec test file in the appropriate namespace directory if RSpec is detected" do
+      allow(File).to receive(:exist?).with(anything).and_call_original
+      allow(File).to receive(:exist?).with(File.join(destination_root, "spec/spec_helper.rb")).and_return(true)
+
+      run_generator %w[CreateUser Admin]
+
+      assert_file "spec/operations/admin/create_user_spec.rb", /RSpec.describe Admin::CreateUser, type: :operation do/
+    end
+  end
+end


### PR DESCRIPTION
- Implemented `rails generate operation NAME NAMESPACE` command to generate operation files, with optional namespace support.
- Created templates for operation classes and tests (RSpec and MiniTest).
- Added logic to detect the testing framework (RSpec or MiniTest) and generate the corresponding test file, or skip test generation if no supported framework is found.
- Updated `.gitignore` to ignore `spec/tmp` files.
- Added unit tests for the new `OperationGenerator` class.