### PR TITLE
Updated gem dependencies to avoid open-ended version warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [1.0.1] - 2025-04-23
+
+### Changed
+- Updated gem dependencies to avoid open-ended version warnings:
+    - Changed `faraday` from `>= 2.0` to `~> 2.3`
+    - Changed `faraday-typhoeus` from `>= 0` to `~> 1.1`
+    - Changed `faraday-follow_redirects` from `>= 0` to `~> 0.3.0`
+
 ## [1.0.0] - 2025-04-23
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    rails_cosmos (1.0.0)
-      faraday (>= 2.0)
-      faraday-follow_redirects
-      faraday-typhoeus
+    rails_cosmos (1.0.1)
+      faraday (~> 2.3)
+      faraday-follow_redirects (~> 0.3.0)
+      faraday-typhoeus (~> 1.1)
       rails (~> 7.0)
 
 GEM

--- a/lib/rails_cosmos/version.rb
+++ b/lib/rails_cosmos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsCosmos
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/rails_cosmos.gemspec
+++ b/rails_cosmos.gemspec
@@ -47,9 +47,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", "~> 7.0"
-  spec.add_dependency "faraday", ">= 2.0"
-  spec.add_dependency "faraday-typhoeus"
-  spec.add_dependency "faraday-follow_redirects"
+  spec.add_dependency "faraday", "~> 2.3"
+  spec.add_dependency "faraday-typhoeus", "~> 1.1"
+  spec.add_dependency "faraday-follow_redirects", "~> 0.3.0"
 
   spec.add_development_dependency "generator_spec", "~> 0.10.0"
 end


### PR DESCRIPTION
### Changed
  - Changed `faraday` from `>= 2.0` to `~> 2.3`
  - Changed `faraday-typhoeus` from `>= 0` to `~> 1.1`
  - Changed `faraday-follow_redirects` from `>= 0` to `~> 0.3.0`
